### PR TITLE
Sync two FFT managers so they agree for basic inputs

### DIFF
--- a/FFTManager_fftw.cpp
+++ b/FFTManager_fftw.cpp
@@ -6,29 +6,29 @@
 
 struct FFTManager {
     unsigned int N;
-    fftw_complex *in;
-    fftw_complex *out;
+    fftwf_complex *in;
+    fftwf_complex *out;
     float* multipliers;
-    fftw_plan p;
+    fftwf_plan p;
 };
 
 void setupHammingWindow(float *values, int N) {
     for (int i = 0; i < N; ++i) {
-        values[i] = 0.54 - 0.46 * cos(2*M_PI*i/(N-1));
+        values[i] = 0.54f - 0.46f * cosf(2.f*M_PI*i/(N-1));
     }
 }
 
 FFTManager* createFFTManager(int sampleSize) {
-  FFTManager* _fft = (struct FFTManager*) malloc(sizeof(struct FFTManager));
-  _fft->N = sampleSize;
-  _fft->in = fftw_alloc_complex(sampleSize);
-  _fft->out = fftw_alloc_complex(sampleSize);
-  _fft->p = fftw_plan_dft_1d(sampleSize, _fft->in, _fft->out, FFTW_FORWARD, FFTW_MEASURE);
+    FFTManager* _fft = (struct FFTManager*) malloc(sizeof(struct FFTManager));
+    _fft->N = sampleSize;
+    _fft->in = fftwf_alloc_complex(sampleSize);
+    _fft->out = fftwf_alloc_complex(sampleSize);
+    _fft->p = fftwf_plan_dft_1d(sampleSize, _fft->in, _fft->out, FFTW_FORWARD, FFTW_MEASURE);
 
-  _fft->multipliers = (float*) malloc(sizeof(float) * sampleSize);
-  setupHammingWindow(_fft->multipliers, sampleSize);
+    _fft->multipliers = (float*) malloc(sizeof(float) * sampleSize);
+    setupHammingWindow(_fft->multipliers, sampleSize);
 
-  return _fft;
+    return _fft;
 }
 
 void fft(FFTManager *_fft, float * input, int inputSize, float *output) {
@@ -43,7 +43,7 @@ void fft(FFTManager *_fft, float * input, int inputSize, float *output) {
         _fft->in[i][1] = 0.0;
     }
 
-    fftw_execute(_fft->p);
+    fftwf_execute(_fft->p);
 
     // Compute *squared* magnitudes
     for (int i = 0; i <= _fft->N/2; ++i) {
@@ -52,9 +52,9 @@ void fft(FFTManager *_fft, float * input, int inputSize, float *output) {
 }
 
 void deleteFFTManager(FFTManager *_fft) {
-    fftw_destroy_plan(_fft->p);
-    fftw_free(_fft->in);
-    fftw_free(_fft->out);
+    fftwf_destroy_plan(_fft->p);
+    fftwf_free(_fft->in);
+    fftwf_free(_fft->out);
     free(_fft);
 }
 


### PR DESCRIPTION
I made the fftw version single-precision, but most of the change is to use a homebrew hamming window. 

Some examples of hamming windows in the wild:

https://developer.apple.com/library/mac/documentation/Accelerate/Reference/vDSPRef/#//apple_ref/c/func/vDSP_hamm_window

http://docs.scipy.org/doc/numpy-1.10.0/reference/generated/numpy.hamming.html

https://en.wikipedia.org/wiki/Window_function#Hamming_window

http://www.mathworks.com/help/signal/ref/hamming.html

https://www.dsprelated.com/freebooks/sasp/Matlab_Hamming_Window.html
